### PR TITLE
Move try-catch-block into retry-loop in LocalHueApi

### DIFF
--- a/src/HueApi/LocalHueApi.cs
+++ b/src/HueApi/LocalHueApi.cs
@@ -56,9 +56,9 @@ namespace HueApi
 
       var cancelToken = this.eventStreamCancellationTokenSource.Token;
 
-      try
+      while (!cancelToken.IsCancellationRequested) //Auto retry on stop
       {
-        while (!cancelToken.IsCancellationRequested) //Auto retry on stop
+        try
         {
 #if NET461
           using (var streamReader = new StreamReader(await client.GetStreamAsync(EventStreamUrl)))
@@ -83,10 +83,10 @@ namespace HueApi
             }
           }
         }
-      }
-      catch (TaskCanceledException)
-      {
-        //Ignore task canceled
+        catch (TaskCanceledException ex)
+        {
+          //Ignore task canceled
+        }
       }
     }
 


### PR DESCRIPTION
If an exception occurs in the eventStreamReader, it is catched outside of the while-loop (retry-logic).

This happens often with my bridge due to some timeout. As the Exception is swallowed in an empty catchblock, i can not react to this in my application. If i move the try-catch-block  into the while-loop, it works stable.

Message (TaskCanceledException):
"The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing."

Stacktrace:
   at System.Net.Http.HttpClient.HandleFailure(Exception e, Boolean telemetryStarted, HttpResponseMessage response, CancellationTokenSource cts, CancellationToken cancellationToken, CancellationTokenSource pendingRequestsCts)
   at System.Net.Http.HttpClient.<GetStreamAsyncCore>d__51.MoveNext()
   at HueApi.LocalHueApi.<StartEventStream>d__7.MoveNext() in C:\_DEV\Q42.HueApi\src\HueApi\LocalHueApi.cs:line 66
