### PR TITLE
Add ZLLRelativeRotary model properties to support Hue Tap Dial switch

### DIFF
--- a/src/Q42.HueApi/Models/Sensors/Sensor.cs
+++ b/src/Q42.HueApi/Models/Sensors/Sensor.cs
@@ -25,6 +25,7 @@ namespace Q42.HueApi.Models
       ZGPSwitch,
       ZLLPresence,
       ZLLSwitch,
+      ZLLRelativeRotary,
       ZLLTemperature
   {
     [JsonProperty("state")]
@@ -76,10 +77,20 @@ namespace Q42.HueApi.Models
       ZGPSwitchState,
       ZLLPresenceState,
       ZLLSwitchState,
+      ZLLRelativeRotaryState,
       ZLLTemperatureState
   {
     [JsonProperty("buttonevent")]
     public int? ButtonEvent { get; set; }
+
+    [JsonProperty("rotaryevent")]
+    public int? RotaryEvent { get; set; }
+
+    [JsonProperty("expectedrotation")]
+    public int? ExpectedRotation { get; set; }
+
+    [JsonProperty("expectedeventduration")]
+    public int? ExpectedEventDuration { get; set; }
 
     [JsonProperty("dark")]
     public bool? Dark { get; set; }
@@ -125,6 +136,7 @@ namespace Q42.HueApi.Models
       ZGPSwitchConfig,
       ZLLPresenceConfig,
       ZLLSwitchConfig,
+      ZLLRelativeRotaryConfig,
       ZLLTemperatureConfig
   {
     [JsonProperty("alert")]
@@ -205,6 +217,9 @@ namespace Q42.HueApi.Models
   {
     [JsonProperty("buttonevent")]
     public int ButtonEvent { get; set; }
+
+    [JsonProperty("rotaryevent")]
+    public int RotaryEvent { get; set; }
 
     [JsonProperty("eventtype")]
     public string EventType { get; set; } = default!;

--- a/src/Q42.HueApi/Models/Sensors/ZigBee/ZLLRelativeRotary.cs
+++ b/src/Q42.HueApi/Models/Sensors/ZigBee/ZLLRelativeRotary.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Q42.HueApi.Models.Sensors.ZigBee
+{
+  /// <summary>
+  /// Hue Tap Dial Switch)
+  /// </summary>
+  public interface ZLLRelativeRotary : GeneralSensor
+  {
+    string ProductId { get; set; }
+
+    string SwConfigId { get; set; }
+  }
+
+  public interface ZLLRelativeRotaryConfig : GeneralSensorConfig
+  {
+  }
+
+  public interface ZLLRelativeRotaryState : GeneralSensorState
+  {
+    /// <summary>
+    /// See: http://www.developers.meethue.com/documentation/supported-sensors
+    /// </summary>
+    int? RotaryEvent { get; set; }
+    int? ExpectedRotation { get; set; }
+    int? ExpectedEventDuration { get; set; }
+
+  }
+}


### PR DESCRIPTION
Specification per https://developers.meethue.com/develop/hue-api/supported-devices/ section 4.4.

The Hue Tap Dial switch exposes two sensors - the first to support the button, and the second to support the dial. The dial sensor exposes `rotaryevent` in place of `buttonevent` on both `capabilities` and `state`, with a couple of extra properties on `state`.

I'm aware that this version of the library is legacy, but as the v2 API does not support rule editing I'm hoping you're still happy to review PRs.